### PR TITLE
feat(dataset): add MMU mode alongside GFW & JRC

### DIFF
--- a/src/app/(content)/[country]/[year]/page.tsx
+++ b/src/app/(content)/[country]/[year]/page.tsx
@@ -37,7 +37,8 @@ export default async function Page({ params, searchParams }: PageProps) {
   const details = getCountryDetails({ country, slug });
 
   // Validate dataset parameter - default to JRC if not specified or invalid
-  const validDataset: DatasetType = dataset === "GFW" ? "GFW" : "JRC";
+  const validDataset: DatasetType =
+    dataset === "GFW" ? "GFW" : dataset === "MMU" ? "MMU" : "JRC";
 
   return (
     <div>

--- a/src/components/maps/MapLegends.tsx
+++ b/src/components/maps/MapLegends.tsx
@@ -81,6 +81,43 @@ export function LegendsForGFW() {
     </div>
   );
 }
+// Placeholder: copies JRC legend until MMU-specific copy is provided.
+export function LegendsForMMU() {
+  return (
+    <div className="text-center">
+      <div className="space-y-2">
+        <div className="flex items-start gap-2 text-sm">
+          <div className="shrink-0 w-8 h-6 border border-black bg-[#C4C4C4]"></div>
+          <div className="text-left md:max-w-1/2">
+            <p>Currently ineligible rainforest countries</p>
+            <p className="text-xs text-gray-600">
+              Deforestation rate over 0.5%
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2 text-sm">
+          <div className="shrink-0 w-8 h-6 border border-black bg-[#8FBDF1]"></div>
+          <div className="text-left md:max-w-1/2">
+            <p>Almost eligible</p>
+            <p className="text-xs text-gray-600">
+              Deforestation rate under 0.5% but increase in deforestation rate
+              from 2023 to 2024
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2 text-sm">
+          <div className="shrink-0 w-8 h-6 border border-black bg-[#6FCF97]"></div>
+          <div className="text-left md:max-w-1/2">
+            <p>Fully eligible countries</p>
+            <p className="text-xs text-gray-600">Pass both criteria</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 export function CountryMapLegends() {
   return (
     <div className="flex typo-p">

--- a/src/components/maps/country/CountryMap.tsx
+++ b/src/components/maps/country/CountryMap.tsx
@@ -103,7 +103,8 @@ export default function CountryMap({
             name: country.name,
             year,
             iso2: country.iso2,
-            dataset, // Include dataset in API call
+            // MMU has no layers endpoint yet — reuse JRC layers as placeholder.
+            dataset: dataset === "MMU" ? "JRC" : dataset,
           },
         });
         setLayersData(result);
@@ -204,8 +205,10 @@ export default function CountryMap({
           </>
         )}
 
-        {showLayers && layersData && dataset === "JRC" && (
-          <>
+        {showLayers &&
+          layersData &&
+          (dataset === "JRC" || dataset === "MMU") && (
+            <>
             {/* JRC Mode: Tropical forest layer (bottom) */}
             <Source
               key={`total-tropical-forest-${dataset}`}

--- a/src/components/maps/shared/DatasetTabs.tsx
+++ b/src/components/maps/shared/DatasetTabs.tsx
@@ -92,6 +92,11 @@ export default function DatasetTabs({
       label: "Tree-cover-change Estimate (GFW)",
       description: "",
     },
+    {
+      key: "MMU",
+      label: "MMU",
+      description: "",
+    },
   ];
 
   const baseTabClasses =

--- a/src/components/maps/shared/types.ts
+++ b/src/components/maps/shared/types.ts
@@ -51,6 +51,7 @@ export interface WorldMapState {
   forestData: {
     GFW: CountryForestRecord[];
     JRC: CountryForestRecord[];
+    MMU: CountryForestRecord[];
   };
   isLoading: boolean;
 }

--- a/src/components/maps/world/WorldMap.tsx
+++ b/src/components/maps/world/WorldMap.tsx
@@ -51,6 +51,7 @@ export default function WorldMap({ onCountryClick }: WorldMapProps = {}) {
         colorKey: "#E1EBE5", // Blank/neutral color
         JRCColorKey: "#E1EBE5",
         GFWColorKey: "#E1EBE5",
+        MMUColorKey: "#E1EBE5",
         countrySlug: "",
       },
     }));
@@ -62,6 +63,10 @@ export default function WorldMap({ onCountryClick }: WorldMapProps = {}) {
     // Filter GFW data by selected year
     const gfwDataAll = forestData.GFW || [];
     const gfwData = gfwDataAll.filter((item) => item.year == selectedYear);
+
+    // Filter MMU data by selected year
+    const mmuDataAll = forestData.MMU || [];
+    const mmuData = mmuDataAll.filter((item) => item.year == selectedYear);
 
     // Update JRC colors if we have JRC data
     let featuresWithColors = blankFeatures;
@@ -104,6 +109,26 @@ export default function WorldMap({ onCountryClick }: WorldMapProps = {}) {
       });
     }
 
+    // Update MMU colors if we have MMU data
+    if (mmuData.length > 0) {
+      const transformedMMU = transformAllForestCoverChangeData(mmuData);
+      featuresWithColors = featuresWithColors.map((country) => {
+        const countrySlug = country.properties.countrySlug as string;
+        const countyISO2 = country.properties.iso_a2 as string;
+        const mmuEligibility = transformedMMU[countyISO2]?.eligibility;
+        const mmuColorKey = eligibilityColor(mmuEligibility || "NA");
+
+        return {
+          ...country,
+          properties: {
+            ...country.properties,
+            countrySlug,
+            MMUColorKey: mmuColorKey,
+          },
+        };
+      });
+    }
+
     return {
       ...countries,
       features: featuresWithColors,
@@ -113,7 +138,7 @@ export default function WorldMap({ onCountryClick }: WorldMapProps = {}) {
   const onClick = (event: maplibregl.MapLayerMouseEvent) => {
     const map = mapRef.current?.getMap();
     const features = map?.queryRenderedFeatures(event.point, {
-      layers: ["country-fill-jrc", "country-fill-gfw"],
+      layers: ["country-fill-jrc", "country-fill-gfw", "country-fill-mmu"],
     });
     const { point } = event;
     const country = features?.[0]?.properties?.name_long;
@@ -195,6 +220,15 @@ export default function WorldMap({ onCountryClick }: WorldMapProps = {}) {
                   "fill-opacity": selectedDataset === "GFW" ? 1 : 0,
                 }}
               />
+              {/* MMU Layer */}
+              <Layer
+                id="country-fill-mmu"
+                type="fill"
+                paint={{
+                  "fill-color": ["get", "MMUColorKey"],
+                  "fill-opacity": selectedDataset === "MMU" ? 1 : 0,
+                }}
+              />
               <Layer
                 id="country-line"
                 type="line"
@@ -235,7 +269,9 @@ export default function WorldMap({ onCountryClick }: WorldMapProps = {}) {
                   colorKey:
                     selectedDataset === "JRC"
                       ? feature.properties.JRCColorKey
-                      : feature.properties.GFWColorKey,
+                      : selectedDataset === "MMU"
+                        ? feature.properties.MMUColorKey
+                        : feature.properties.GFWColorKey,
                 },
               })),
             };

--- a/src/components/sections/charts/AnnualPayoutAreaChart.tsx
+++ b/src/components/sections/charts/AnnualPayoutAreaChart.tsx
@@ -2,6 +2,7 @@
 
 import { toReadable } from "@/lib/format";
 import { useForestCoverChangeData } from "@/stores/forest-cover.store";
+import { useWorldMapStore } from "@/stores/map.store";
 import { useEffect, useState } from "react";
 import { Area, AreaChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
 
@@ -17,14 +18,18 @@ type ChartData = {
 
 export default function AnnualPayoutAreaChart() {
   const { forestCoverChangeDataByCountry } = useForestCoverChangeData();
+  const { selectedDataset } = useWorldMapStore();
 
   const [chartData, setChartData] = useState<ChartData[]>([]);
+
+  // MMU data starts at 2021; other datasets at 2019.
+  const minYear = selectedDataset === "MMU" ? 2020 : 2018;
 
   useEffect(() => {
     if (!forestCoverChangeDataByCountry?.length) return;
 
     const _chartData = forestCoverChangeDataByCountry
-      .filter((el) => +el.year > 2018)
+      .filter((el) => +el.year > minYear)
       .map((el) => ({
         year: el.year,
         value:
@@ -34,7 +39,7 @@ export default function AnnualPayoutAreaChart() {
       }));
 
     setChartData(_chartData);
-  }, [forestCoverChangeDataByCountry]);
+  }, [forestCoverChangeDataByCountry, minYear]);
 
   return (
     <div>

--- a/src/components/sections/charts/ForestCoverChangeAreaChart.tsx
+++ b/src/components/sections/charts/ForestCoverChangeAreaChart.tsx
@@ -2,6 +2,7 @@
 
 import { toReadable } from "@/lib/format";
 import { useForestCoverChangeData } from "@/stores/forest-cover.store";
+import { useWorldMapStore } from "@/stores/map.store";
 import { useEffect, useMemo, useState } from "react";
 import {
   Area,
@@ -77,13 +78,17 @@ const RightYAxisTick = ({ x, y, payload }: AxisTickProps) => {
 
 export default function ForestCoverChangeAreaChart() {
   const { forestCoverChangeDataByCountry } = useForestCoverChangeData();
+  const { selectedDataset } = useWorldMapStore();
   const [chartData, setChartData] = useState<ChartData[]>([]);
+
+  // MMU data starts at 2021; other datasets at 2019.
+  const minYear = selectedDataset === "MMU" ? 2020 : 2018;
 
   useEffect(() => {
     if (!forestCoverChangeDataByCountry?.length) return;
 
     const _chartData = forestCoverChangeDataByCountry
-      .filter((el) => +el.year > 2018)
+      .filter((el) => +el.year > minYear)
       .map((el) => ({
         year: el.year,
         degradation: -el.degraded_forest_ha,
@@ -91,7 +96,7 @@ export default function ForestCoverChangeAreaChart() {
       }));
 
     setChartData(_chartData);
-  }, [forestCoverChangeDataByCountry]);
+  }, [forestCoverChangeDataByCountry, minYear]);
 
   const { leftDomainMin, rightDomainMin } = useMemo(() => {
     if (!chartData.length)

--- a/src/components/sections/charts/Top10BarChart.tsx
+++ b/src/components/sections/charts/Top10BarChart.tsx
@@ -14,3 +14,11 @@ export function JRC10CountriesChart() {
     </div>
   );
 }
+// Placeholder: reuses JRC image until an MMU-specific chart is provided.
+export function MMU10CountriesChart() {
+  return (
+    <div>
+      <Image width={1440} height={833} src="/assets/Top-10-JRC.png" alt="" />
+    </div>
+  );
+}

--- a/src/components/sections/hero/TFFFMapView.tsx
+++ b/src/components/sections/hero/TFFFMapView.tsx
@@ -12,6 +12,7 @@ import {
   CountryMapLegends,
   LegendsForGFW,
   LegendsForJRC,
+  LegendsForMMU,
 } from "@/components/maps/MapLegends";
 import {
   CountryMapHeaderContent,
@@ -19,6 +20,7 @@ import {
 } from "@/components/sections/hero/TFFFMapViewContent";
 import { Spacer } from "@/components/ui/layout";
 import { CountryDetails } from "@/domain/country.types";
+import { DatasetType } from "@/domain/dataset";
 import { asCountrySlug } from "@/domain/brand";
 import { useForestCoverChangeData } from "@/stores/forest-cover.store";
 import { useParams, useSearchParams } from "next/navigation";
@@ -28,6 +30,7 @@ import { fetchForestCoverChangeDataV2 } from "@/utils/forestChange.store";
 import {
   GFWTop10CountriesChart,
   JRC10CountriesChart,
+  MMU10CountriesChart,
 } from "../charts/Top10BarChart";
 import HeaderCountry from "@/components/HeaderCountry";
 
@@ -99,7 +102,13 @@ export function TFFFWorldMapView() {
 
           <div className="mb-8 md:mb-0 md:absolute left-0 bottom-0 min-w-48 max-w-fit pointer-events-none">
             <Spacer className="md:hidden" />
-            {selectedDataset === "JRC" ? <LegendsForJRC /> : <LegendsForGFW />}
+            {selectedDataset === "JRC" ? (
+              <LegendsForJRC />
+            ) : selectedDataset === "MMU" ? (
+              <LegendsForMMU />
+            ) : (
+              <LegendsForGFW />
+            )}
             <Spacer />
           </div>
         </div>
@@ -109,6 +118,8 @@ export function TFFFWorldMapView() {
       <RewardsChart />
       {selectedDataset === "JRC" ? (
         <JRC10CountriesChart />
+      ) : selectedDataset === "MMU" ? (
+        <MMU10CountriesChart />
       ) : (
         <GFWTop10CountriesChart />
       )}
@@ -118,7 +129,7 @@ export function TFFFWorldMapView() {
 
 type TFFFCountryMapViewProps = CountryDetails & {
   year: string;
-  dataset?: "GFW" | "JRC";
+  dataset?: DatasetType;
 };
 
 function TFFFCountryMapViewInner(props: TFFFCountryMapViewProps) {
@@ -127,7 +138,7 @@ function TFFFCountryMapViewInner(props: TFFFCountryMapViewProps) {
 
   // Get dataset from URL params, fallback to props or default
   const selectedDataset =
-    (searchParams.get("dataset") as "GFW" | "JRC") || props.dataset || "JRC";
+    (searchParams.get("dataset") as DatasetType) || props.dataset || "JRC";
 
   useEffect(() => {
     if (props.name && props.iso2) {

--- a/src/components/ui/YearSelect.tsx
+++ b/src/components/ui/YearSelect.tsx
@@ -4,7 +4,7 @@ import { useWorldMapStore } from "@/stores/map.store";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import Image from "next/image";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
 type Props = {
@@ -16,10 +16,10 @@ function YearSelectContent({ initialValue, onChange }: Props) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const { setSelectedYear } = useWorldMapStore();
+  const { setSelectedYear, selectedDataset } = useWorldMapStore();
 
   const [selectedId, setSelectedId] = useState(0);
-  const [options] = useState<
+  const [allOptions] = useState<
     { id: number; value: string; label: string; additionalLabels?: string[] }[]
   >([
     { id: 0, value: "2024", label: "2024" },
@@ -37,6 +37,46 @@ function YearSelectContent({ initialValue, onChange }: Props) {
     // },
   ]);
 
+  // MMU data only goes back to 2021; other datasets back to 2018.
+  const minYear = selectedDataset === "MMU" ? 2021 : 2018;
+  const options = useMemo(
+    () => allOptions.filter((el) => +el.value >= minYear),
+    [allOptions, minYear]
+  );
+
+  // When switching to a dataset with a narrower year range (e.g. MMU),
+  // snap an out-of-range selected year to the latest valid year + sync URL.
+  useEffect(() => {
+    const current = allOptions.find((el) => el.id === selectedId);
+    if (current && +current.value < minYear) {
+      const snapped = options[0];
+      setSelectedId(snapped.id);
+      setSelectedYear(snapped.value);
+
+      const pathSegments = pathname.split("/");
+      const yearIndex = pathSegments.findIndex((segment) =>
+        /^\d{4}$/.test(segment)
+      );
+      if (yearIndex !== -1) {
+        pathSegments[yearIndex] = snapped.value;
+        const newPath = pathSegments.join("/");
+        const queryString = searchParams.toString();
+        router.push(queryString ? `${newPath}?${queryString}` : newPath, {
+          scroll: false,
+        });
+      }
+    }
+  }, [
+    minYear,
+    options,
+    allOptions,
+    selectedId,
+    setSelectedYear,
+    pathname,
+    router,
+    searchParams,
+  ]);
+
   useEffect(() => {
     if (!initialValue) {
       const selected = options[0];
@@ -45,7 +85,10 @@ function YearSelectContent({ initialValue, onChange }: Props) {
       return;
     }
 
-    const selected = options.find((el) => el.value === initialValue)!;
+    // Fall back to the latest valid year if initialValue is out of range
+    // for the current dataset (e.g. a pre-2021 year while MMU is active).
+    const selected =
+      options.find((el) => el.value === initialValue) ?? options[0];
     setSelectedId(selected.id);
     setSelectedYear(selected.value);
   }, [initialValue, options, setSelectedYear]);

--- a/src/domain/dataset.ts
+++ b/src/domain/dataset.ts
@@ -1,2 +1,2 @@
 // The two forest-data sources. Canonical home for the dataset discriminator.
-export type DatasetType = "GFW" | "JRC";
+export type DatasetType = "GFW" | "JRC" | "MMU";

--- a/src/stores/map.store.ts
+++ b/src/stores/map.store.ts
@@ -12,7 +12,7 @@ interface WorldMapStore extends WorldMapState {
   setIsLoading: (loading: boolean) => void;
   getCurrentForestData: () => CountryForestRecord[];
   getSelectedCountryData: () => CountryForestRecord | null;
-  datasetFetched: { GFW: boolean; JRC: boolean };
+  datasetFetched: { GFW: boolean; JRC: boolean; MMU: boolean };
   markDatasetFetched: (dataset: DatasetType) => void;
   resetDatasetFetched: () => void;
 }
@@ -22,9 +22,9 @@ export const useWorldMapStore = create<WorldMapStore>((set, get) => ({
   selectedYear: "2024",
   selectedDataset: "JRC",
   clickPosition: null,
-  forestData: { GFW: [], JRC: [] },
+  forestData: { GFW: [], JRC: [], MMU: [] },
   isLoading: false,
-  datasetFetched: { GFW: false, JRC: false },
+  datasetFetched: { GFW: false, JRC: false, MMU: false },
 
   setSelectedCountry: (country) => set({ selectedCountry: country }),
   setSelectedYear: (year) =>
@@ -48,7 +48,7 @@ export const useWorldMapStore = create<WorldMapStore>((set, get) => ({
     })),
   resetDatasetFetched: () =>
     set({
-      datasetFetched: { GFW: false, JRC: false },
+      datasetFetched: { GFW: false, JRC: false, MMU: false },
     }),
 
   getCurrentForestData: () => {

--- a/src/utils/forestChange.store.ts
+++ b/src/utils/forestChange.store.ts
@@ -12,7 +12,7 @@ export async function fetchForestCoverChangeDataV2({
   country?: string;
   year?: string;
   iso2?: string;
-  source?: "GFW" | "JRC";
+  source?: "GFW" | "JRC" | "MMU";
 }) {
   const query: { [key: string]: string } = {};
 


### PR DESCRIPTION
## Context

Adds a third dataset mode **MMU** to the world map, home charts, and country views, alongside existing **GFW** and **JRC**. MMU data flows through the existing free-string `source` query param — no backend/API change needed.

## Changes

**Types/store**
- `DatasetType` union + `source` param widened with `"MMU"`
- `forestData` / `datasetFetched` keyed with `MMU`

**Home / world map**
- 3rd tab "MMU" (JRC stays default)
- `MMUColorKey` map layer with opacity toggle, click hit-test, SVG download
- `LegendsForMMU` + 3-way legend/chart branches
- `MMU10CountriesChart` — **placeholder** reusing JRC two-sided bar image

**Country page**
- `?dataset=MMU` validated
- MMU **reuses JRC layers** (sends `dataset=JRC` to `/api/layers`, renders JRC block) — no MMU tiles yet, per scope

**Year logic (dataset-aware)**
- MMU year selector limited to **2021–2024**; snaps out-of-range year + syncs URL
- Country Line/Area charts filter `> 2020` for MMU (GFW/JRC unchanged at `> 2018`)

## Out of scope (placeholders)
- No MMU-specific layer tiles/endpoints (reuse JRC)
- No MMU-specific two-sided bar chart image (reuse JRC)
- Legend/tooltip copy left as JRC text

## Verification
- `npx tsc --noEmit` clean
- Home: 3 tabs; MMU click → `?dataset=MMU`, `forest_change_and_payouts-v2?source=MMU` → 200
- Country `/brazil/2024?dataset=MMU`: `/api/layers` 200 (JRC layers), `tfff-forest-change-and-payouts?source=MMU` 200, JRC placeholder chart loads
- No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)